### PR TITLE
Fix z-index on ql-table-properties-form

### DIFF
--- a/src/assets/css/quill-table-better.scss
+++ b/src/assets/css/quill-table-better.scss
@@ -248,6 +248,7 @@ $border: 1px solid $color-ccced1;
   left: 50%;
   padding-bottom: 12px;
   background: $color-white;
+  z-index: 1;
   @include boxShadow($color-ccced1);
   &::before {
     @extend .ql-table-triangle-common;


### PR DESCRIPTION
While testing this table module, I noticed that it doesn't properly show menus when placed inside of the container with `position: relative.` Simple fix on z-index seems to work. I used the value `1`, the same as it can be found on the official quill menus.

**before** 

![image](https://github.com/user-attachments/assets/9f385dc3-abc3-44c4-b9f2-9d60d5cefc92)

**after**

![image](https://github.com/user-attachments/assets/b6e2ba76-5203-46bc-9fa9-9fc97793d26e)
