### PR TITLE
Fix resize issue till change the table size in menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-table-better",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A module that enhances the table functionality of Quill",
   "main": "dist/quill-table-better.js",
   "scripts": {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -347,7 +347,6 @@ function updateTableWidth(
   tableBounds: CorrectBound,
   change: number
 ) {
-  if (!table?.style.getPropertyValue('width')) return;
   const tableBlot = Quill.find(table);
   if (!tableBlot) return;
   const colgroup = tableBlot.colgroup();


### PR DESCRIPTION
This fix addresses the issue where, after adding a table to Quill, I cannot resize it until I change the width inside the 'Dimensions and Alignment' section.
![Screenshot 2025-02-07 143208](https://github.com/user-attachments/assets/3ea54bf4-f164-417e-877b-3cdd81aefe7a)
