### PR TITLE
Add option to have the first row be a table head 

### DIFF
--- a/src/assets/css/quill-table-better.scss
+++ b/src/assets/css/quill-table-better.scss
@@ -516,6 +516,19 @@ button.ql-table-better {
     color: #222f3eb3;
     margin-top: 2px;
   }
+  .ql-table-select-header,
+  .ql-table-select-full-width {
+    width: 100%;
+    line-height: 16px;
+    margin-left: 5px;
+    text-align: left;
+    color: #333;
+
+    input {
+      vertical-align: bottom;
+    }
+  }
+
   span {
     width: 16px;
     height: 16px;
@@ -534,4 +547,13 @@ ol.table-list-container {
   40% { transform: translateX(2px); }
   60% { transform: translateX(-1px); }
   80% { transform: translateX(1px); }
+}
+
+// Addition to base theme to apply the same styles to header cell as body cell
+.ql-editor table th {
+  outline: none;
+}
+.ql-editor th {
+  border: 1px solid #000;
+  padding: 2px 5px;
 }

--- a/src/formats/table.ts
+++ b/src/formats/table.ts
@@ -93,7 +93,6 @@ class TableHeadCellBlock extends TableCellBlock {
   static tagName = 'P';
 
   format(name: string, value: string | Props) {
-    const cellId = this.formats()[this.statics.blotName];
     if (name === TableHeadCell.blotName && value) {
       this.wrap(TableHeadRow.blotName);
       return this.wrap(name, value);
@@ -607,20 +606,17 @@ class TableContainer extends Container {
 
   insertColumn(position: number, isLast: boolean, w: number, offset: number) {
     const colgroup = this.colgroup() as TableColgroup;
-    const body = this.tbody() as TableBody;
-    if (body == null || body.children.head == null) return;
     const columnCells: [TableRow, string, TableCell | null, null][] = [];
     const cols: [TableColgroup, TableCol | null][] = [];
-    let row = body.children.head;
-    while (row) {
+    let rows = this.allRows();
+    rows.forEach((row: TableRow) => {
       if (isLast && offset > 0) {
         const id = row.children.tail.domNode.getAttribute('data-row');
         columnCells.push([row, id, null, null]);
       } else {
         this.setColumnCells(row, columnCells, { position, width: w });
       }
-      row = row.next;
-    }
+    });
     if (colgroup) {
       if (isLast) {
         cols.push([colgroup, null]);
@@ -822,6 +818,10 @@ class TableContainer extends Container {
     // @ts-expect-error
     const [body] = this.descendant(TableBody);
     return body || this.findChild('table-body') as TableBody;
+  }
+
+  allRows(): TableRow[] {
+    return this.descendants(TableRow);
   }
 
   temporary() {

--- a/src/formats/table.ts
+++ b/src/formats/table.ts
@@ -474,13 +474,14 @@ class TableContainer extends Container {
   deleteRow(rows: TableRow[], deleteTable: () => void) {
     const body = this.tbody();
     if (body == null || body.children.head == null) return;
-    if (rows.length === body.children.length) {
+    const allRows = this.allRows();
+    if (rows.length === allRows.length) {
       deleteTable();
     } else {
       const weakMap: WeakMap<TableCell, { next: TableRow, rowspan: number }> = new WeakMap();
       const columnCells: [TableRow, Props, TableCell | null, TableCell | null][] = [];
       const keys: TableCell[] = [];
-      const maxColumns = this.getMaxColumns(body.children.head.children);
+      const maxColumns = this.getMaxColumns(allRows[0].children);
       for (const row of rows) {
         const prev = this.getCorrectRow(row, maxColumns);
         prev && prev.children.forEach((child: TableCell) => {

--- a/src/language/de_DE.ts
+++ b/src/language/de_DE.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': 'Türkis',
   'lightBlue': 'Hellblau',
   'blue': 'Blau',
-  'purple': 'Lila'
+  'purple': 'Lila',
+  'firstRowIsHeader': 'Erste Zeile ist eine Kopfzeile',
+  'fullWidth': 'Tabelle mit voller Breite'
 };

--- a/src/language/en_US.ts
+++ b/src/language/en_US.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': 'Turquoise',
   'lightBlue': 'Light blue',
   'blue': 'Blue',
-  'purple': 'Purple'
+  'purple': 'Purple',
+  'firstRowIsHeader': 'First row is a header',
+  'fullWidth': 'Full width table'
 };

--- a/src/language/fr_FR.ts
+++ b/src/language/fr_FR.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': 'Turquoise',
   'lightBlue': 'Bleu clair',
   'blue': 'Bleu',
-  'purple': 'Violet'
+  'purple': 'Violet',
+  'firstRowIsHeader': 'Première ligne en en-tête',
+  'fullWidth': 'Tableau pleine largeur'
 };

--- a/src/language/pl_PL.ts
+++ b/src/language/pl_PL.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': 'Turkusowy',
   'lightBlue': 'Jasnoniebieski',
   'blue': 'Niebieski',
-  'purple': 'Fioletowy'
+  'purple': 'Fioletowy',
+  'firstRowIsHeader': 'Pierwszy wiersz to nagłówek',
+  'fullWidth': 'Tabela o pełnej szerokości'
 };

--- a/src/language/ru_RU.ts
+++ b/src/language/ru_RU.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': 'Бирюзовый',
   'lightBlue': 'Светло-голубой',
   'blue': 'Синий',
-  'purple': 'Фиолетовый'
+  'purple': 'Фиолетовый',
+  'firstRowIsHeader': 'Первая строка - это заголовок',
+  'fullWidth': 'Таблица во всю ширину'
 };

--- a/src/language/tr_TR.ts
+++ b/src/language/tr_TR.ts
@@ -55,6 +55,7 @@ export default {
     'turquoise': 'Turkuaz',
     'lightBlue': 'Açık mavi',
     'blue': 'Mavi',
-    'purple': 'Mor'
+    'purple': 'Mor',
+    'firstRowIsHeader': 'İlk satır bir başlıktır',
+    'fullWidth': 'Tam genişlikte tablo'
   };
-  

--- a/src/language/zh_CN.ts
+++ b/src/language/zh_CN.ts
@@ -55,5 +55,7 @@ export default {
   'turquoise': '青绿色',
   'lightBlue': '浅蓝色',
   'blue': '蓝色',
-  'purple': '紫色'
+  'purple': '紫色',
+  'firstRowIsHeader': '第一行是页眉',
+  'fullWidth': '全宽表格'
 };

--- a/src/modules/clipboard.ts
+++ b/src/modules/clipboard.ts
@@ -3,7 +3,7 @@ import Delta from 'quill-delta';
 import logger from 'quill/core/logger.js';
 import type { Range } from 'quill';
 import type { Props } from '../types';
-import { TableCellBlock, TableTemporary } from '../formats/table';
+import { TableCellBlock, TableHeadCellBlock, TableTemporary } from '../formats/table';
 
 const Module = Quill.import('core/module');
 const Clipboard = Quill.import('modules/clipboard') as typeof Module;
@@ -52,6 +52,28 @@ class TableClipboard extends Clipboard {
             op?.attributes?.header ||
             op?.attributes?.list ||
             !op?.attributes?.[TableCellBlock.blotName]
+        ) {
+          op.attributes = { ...op.attributes, ...formats };
+        }
+      }
+    } else if (formats[TableHeadCellBlock.blotName]) {
+      for (const op of delta.ops) {
+        // External copied tables or table contents copied within an editor.
+        // Subsequent version processing.
+        if (
+          op?.attributes &&
+          (
+            op.attributes[TableTemporary.blotName] ||
+            op.attributes[TableHeadCellBlock.blotName]
+          )
+        ) {
+          return new Delta();
+        }
+        // Process externally pasted lists or headers or text.
+        if (
+            op?.attributes?.header ||
+            op?.attributes?.list ||
+            !op?.attributes?.[TableHeadCellBlock.blotName]
         ) {
           op.attributes = { ...op.attributes, ...formats };
         }

--- a/src/modules/toolbar.ts
+++ b/src/modules/toolbar.ts
@@ -118,6 +118,11 @@ class TableToolbar extends Toolbar {
   }
 
   private toolbarAttach(input: HTMLElement, format: string, e: Event | MouseEvent) {
+    if (input.classList.contains('ql-table-better') && input.querySelector('.ql-table-select-container:not(.ql-hidden)')) {
+      // The dropdown menu is a child of the button, if the click bubbles up to the button but the dropdown
+      // is visible we should just ignore it
+      return;
+    }
     let value;
     if (input.tagName === 'SELECT') {
       // @ts-expect-error

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,7 +31,7 @@ export interface Props {
   [propName: string]: string
 }
 
-export type InsertTableHandler = (rows: number, columns: number) => void;
+export type InsertTableHandler = (rows: number, columns: number, firstRowIsHeader: boolean, fullWidth: boolean) => void;
 
 export type TableCellAllowedChildren = TableCellBlock | TableHeader | ListContainer;
 

--- a/src/ui/cell-selection.ts
+++ b/src/ui/cell-selection.ts
@@ -12,6 +12,7 @@ import type {
   TableRow
 } from '../types';
 import {
+  getAdjacentRow,
   getComputeBounds,
   getComputeSelectedTds,
   getCopyTd,
@@ -458,7 +459,7 @@ class CellSelection {
       }
       const td = up ? this.startTd : this.endTd;
       const cell = Quill.find(td) as TableCell;
-      const targetRow = cell.parent[_key];
+      const targetRow = getAdjacentRow(up, cell);
       const { left: _left, right: _right } = td.getBoundingClientRect();
       if (targetRow) {
         let cellBlot = null;

--- a/src/ui/cell-selection.ts
+++ b/src/ui/cell-selection.ts
@@ -112,7 +112,7 @@ class CellSelection {
 
   getCopyColumns(container: Element) {
     const tr = container.querySelector('tr');
-    const children = Array.from(tr.querySelectorAll('td'));
+    const children = Array.from(tr.querySelectorAll('th,td'));
     return children.reduce((sum: number, td: HTMLTableCellElement) => {
       const colspan = ~~td.getAttribute('colspan') || 1;
       return sum += colspan;
@@ -317,14 +317,14 @@ class CellSelection {
     const table = (e.target as Element).closest('table');
     if (!table) return;
     this.tableBetter.tableMenus.destroyTablePropertiesForm();
-    const startTd = (e.target as Element).closest('td');
+    const startTd = (e.target as Element).closest('th,td');
     this.startTd = startTd;
     this.endTd = startTd;
     this.selectedTds = [startTd];
     startTd.classList.add('ql-cell-focused');
     
     const handleMouseMove = (e: MouseEvent) => {
-      const endTd = (e.target as Element).closest('td');
+      const endTd = (e.target as Element).closest('th,td');
       if (!endTd) return;
       const isEqualNode = startTd.isEqualNode(endTd);
       if (isEqualNode) return;
@@ -525,7 +525,7 @@ class CellSelection {
     const computeBounds = this.getPasteComputeBounds(this.startTd, rightTd, pasteLastRow);
     const pasteTds = this.getPasteTds(getComputeSelectedTds(computeBounds, table.domNode, this.quill.container));
     const copyTds = copyRows.reduce((copyTds: HTMLElement[][], row: HTMLTableRowElement) => {
-      copyTds.push(Array.from(row.querySelectorAll('td')));
+      copyTds.push(Array.from(row.querySelectorAll('th,td')));
       return copyTds;
     }, []);
     const selectedTds: HTMLElement[] = [];

--- a/src/ui/cell-selection.ts
+++ b/src/ui/cell-selection.ts
@@ -20,7 +20,7 @@ import {
   getCorrectCellBlot
 } from '../utils';
 import { applyFormat } from '../utils/clipboard-matchers';
-import { TableCellBlock, TableCell } from '../formats/table';
+import { TableCellBlock, TableCell, TableHeadRow } from '../formats/table';
 import { DEVIATION } from '../config';
 
 const WHITE_LIST = [
@@ -165,7 +165,14 @@ class CellSelection {
     let row = cell.parent;
     while (row && rowspan) {
       // @ts-expect-error
-      row = row[key];
+      if (!row[key]) {
+        // We jumpt to the next table part if we ran out of rows
+        // @ts-expect-error
+        row = row.parent[key]?.children[(key === 'next')? 'head' : 'tail'];
+      } else {
+        // @ts-expect-error
+        row = row[key];
+      }
       rowspan--;
     }
     return row?.domNode;

--- a/src/ui/operate-line.ts
+++ b/src/ui/operate-line.ts
@@ -1,5 +1,5 @@
 import Quill from 'quill';
-import type {
+import {
   QuillTableBetter,
   TableCell,
   TableColgroup
@@ -186,7 +186,7 @@ class OperateLine {
 
   handleMouseMove(e: MouseEvent) {
     const tableNode = (e.target as Element).closest('table');
-    const cellNode = (e.target as Element).closest('td');
+    const cellNode = (e.target as Element).closest('td,th') as HTMLElement;
     const mousePosition = {
       clientX: e.clientX,
       clientY: e.clientY
@@ -243,7 +243,8 @@ class OperateLine {
       }
     } else {
       const isLastCell = cell.nextElementSibling == null;
-      const rows = cell.parentElement.parentElement.children;
+      //const rows = cell.parentElement.parentElement.children;
+      const rows = cell.parentElement.parentElement.parentElement.querySelectorAll('tr');
       const preNodes: [Element, string][] = [];
       for (const row of rows) {
         const cells = row.children;

--- a/src/ui/operate-line.ts
+++ b/src/ui/operate-line.ts
@@ -243,7 +243,6 @@ class OperateLine {
       }
     } else {
       const isLastCell = cell.nextElementSibling == null;
-      //const rows = cell.parentElement.parentElement.children;
       const rows = cell.parentElement.parentElement.parentElement.querySelectorAll('tr');
       const preNodes: [Element, string][] = [];
       for (const row of rows) {

--- a/src/ui/table-properties-form.ts
+++ b/src/ui/table-properties-form.ts
@@ -595,7 +595,7 @@ class TablePropertiesForm {
   saveTableAction() {
     const { table, tableBetter } = this.tableMenus;
     const temporary = (Quill.find(table) as TableContainer).temporary()?.domNode;
-    const td = table.querySelector('td');
+    const td = table.querySelector('td,tr');
     const attrs = this.getDiffProperties();
     const align = attrs['align'];
     delete attrs['align'];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,12 +3,17 @@ import type {
   CorrectBound,
   Props,
   TableCellChildren,
-  TableContainer
+  TableContainer,
 } from '../types';
 import {
+  TableBody,
   TableCell,
   TableCellBlock,
-  TableCol
+  TableCol,
+  TableHead,
+  TableRow,
+  TableHeadCell,
+  TableHeadRow
 } from '../formats/table';
 import TableList, { ListContainer } from '../formats/list';
 import TableHeader from '../formats/header';
@@ -221,7 +226,7 @@ function getCorrectBounds(target: Element, container: Element) {
 
 function getCorrectCellBlot(blot: TableCell | TableCellChildren): TableCell | null {
   while (blot) {
-    if (blot.statics.blotName === TableCell.blotName) {
+    if (blot.statics.blotName === TableCell.blotName || blot.statics.blotName === TableHeadCell.blotName) {
       // @ts-ignore
       return blot;
     }
@@ -229,6 +234,24 @@ function getCorrectCellBlot(blot: TableCell | TableCellChildren): TableCell | nu
     blot = blot.parent;
   }
   return null;
+}
+
+function getAdjacentRow(up: boolean, blot: TableCell | TableCellChildren): TableRow {
+  const key = up ? 'prev' : 'next';
+  const similarAdjacent = blot.parent[key];
+  if (!similarAdjacent) {
+    // There is no adjacent row in the same category (head or body), let's see if there is one in the other category
+    if (up && blot.parent.parent.statics.blotName === TableBody.blotName) {
+      const table = blot.parent.parent.parent;
+      const rows = table.descendants(TableHeadRow);
+      return rows.pop() as TableRow;
+    } else if (!up && blot.parent.parent.statics.blotName === TableHead.blotName) {
+      const table = blot.parent.parent.parent;
+      const rows = table.descendants(TableRow).filter(row => row.statics.blotName === TableRow.blotName);
+      return rows.shift() as TableRow;
+    }
+  }
+  return similarAdjacent as TableRow;
 }
 
 function getElementStyle(node: HTMLElement, rules: string[]) {
@@ -395,6 +418,7 @@ export {
   getCopyTd,
   getCorrectBounds,
   getCorrectCellBlot,
+  getAdjacentRow,
   getElementStyle,
   isDimensions,
   isValidColor,


### PR DESCRIPTION
This will optionally add a semantically correct header (thead>tr>th) as the first row which is better than having hx in normal cells accessibility-wise . Also adds a full width option when creating the table. I've added the translations for the new text I added but other then French and German they are automated and I can't vouch for their correctness.

You don't have a contributing guide so I tried to stick with the way things are current done in you code but feel free to ask for any changes at all!