### PR TITLE
Add explicit button type to prevent form submission

### DIFF
--- a/src/ui/table-properties-form.ts
+++ b/src/ui/table-properties-form.ts
@@ -64,8 +64,8 @@ interface ColorList {
 }
 
 const ACTION_LIST = [
-  { icon: saveIcon, label: 'save' },
-  { icon: closeIcon, label: 'cancel' }
+  { icon: saveIcon, label: 'save', type: 'button' },
+  { icon: closeIcon, label: 'cancel', type: 'button' }
 ];
 
 const COLOR_LIST: ColorList[] = [
@@ -116,12 +116,12 @@ class TablePropertiesForm {
     const container = document.createElement('div');
     const fragment = document.createDocumentFragment();
     container.classList.add('properties-form-action-row');
-    for (const { icon, label } of ACTION_LIST) {
+    for (const { icon, label, type } of ACTION_LIST) {
       const button = document.createElement('button');
       const iconContainer = document.createElement('span');
       iconContainer.innerHTML = icon;
       button.appendChild(iconContainer);
-      setElementAttribute(button, { label });
+      setElementAttribute(button, { label, type });
       if (showLabel) {
         const labelContainer = document.createElement('span');
         labelContainer.innerText = useLanguage(label);


### PR DESCRIPTION
## Add explicit button type to prevent form submission

Hi,
I noticed that the buttons in the table properties form didn’t have explicit type attributes, so they defaulted to submit and occasionally triggered unintended form submissions.

### Solution
- Added `type: 'button'` to `ACTION_LIST` configuration
- This prevents buttons from submitting forms and ensures they only trigger their intended click handlers

### Impact
- Fixes unexpected form submission behavior
- Improves user experience when editing table properties
- Maintains existing functionality while preventing browser default submit behavior

### Files Changed
- `src/ui/table-properties-form.ts`