### PR TITLE
v1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quill-table-better",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quill-table-better",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-table-better",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A module that enhances the table functionality of Quill",
   "main": "dist/quill-table-better.js",
   "types": "dist/types/index.d.ts",

--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -63,27 +63,9 @@ class Table extends Module {
   
   static keyboardBindings: { [propName: string]: BindingObject };
   
-  static register() {
-    Quill.register(TableCellBlock, true);
-    Quill.register(TableThBlock, true);
-    Quill.register(TableCell, true);
-    Quill.register(TableTh, true);
-    Quill.register(TableRow, true);
-    Quill.register(TableThRow, true);
-    Quill.register(TableBody, true);
-    Quill.register(TableThead, true);
-    Quill.register(TableTemporary, true);
-    Quill.register(TableContainer, true);
-    Quill.register(TableCol, true);
-    Quill.register(TableColgroup, true);
-    Quill.register({
-      'modules/toolbar': TableToolbar,
-      'modules/clipboard': TableClipboard
-    }, true);
-  }
-
   constructor(quill: Quill, options: Options) {
     super(quill, options);
+    this.register();
     quill.clipboard.addMatcher('td, th', matchTableCell);
     quill.clipboard.addMatcher('tr', matchTable);
     quill.clipboard.addMatcher('col', matchTableCol);
@@ -276,6 +258,25 @@ class Table extends Module {
         this.quill.update(Quill.sources.API);
       }
     });
+  }
+
+  private register() {
+    Quill.register(TableCellBlock, true);
+    Quill.register(TableThBlock, true);
+    Quill.register(TableCell, true);
+    Quill.register(TableTh, true);
+    Quill.register(TableRow, true);
+    Quill.register(TableThRow, true);
+    Quill.register(TableBody, true);
+    Quill.register(TableThead, true);
+    Quill.register(TableTemporary, true);
+    Quill.register(TableContainer, true);
+    Quill.register(TableCol, true);
+    Quill.register(TableColgroup, true);
+    Quill.register({
+      'modules/toolbar': TableToolbar,
+      'modules/clipboard': TableClipboard
+    }, true);
   }
 
   private registerToolbarTable(toolbarTable: boolean) {

--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -65,6 +65,7 @@ class Table extends Module {
   
   static register() {
     Quill.register(TableCellBlock, true);
+    Quill.register(TableThBlock, true);
     Quill.register(TableCell, true);
     Quill.register(TableTh, true);
     Quill.register(TableRow, true);
@@ -76,7 +77,6 @@ class Table extends Module {
     Quill.register(TableCol, true);
     Quill.register(TableColgroup, true);
     Quill.register({
-      [TableThBlock.blotName]: TableThBlock,
       'modules/toolbar': TableToolbar,
       'modules/clipboard': TableClipboard
     }, true);

--- a/src/ui/table-menus.ts
+++ b/src/ui/table-menus.ts
@@ -38,7 +38,8 @@ import {
   TableTh,
   TableRow,
   TableThRow,
-  TableThead
+  TableThead,
+  TableBody
 } from '../formats/table';
 import TablePropertiesForm from './table-properties-form';
 import {
@@ -296,8 +297,10 @@ class TableMenus {
   convertToRow() {
     const tableBlot = Quill.find(this.table) as TableContainer;
     const tbody = tableBlot.tbody();
-    const ref = tbody.children.head;
+    const correctTbody = tbody || this.quill.scroll.create(TableBody.blotName) as TableBody;
+    const ref = correctTbody?.children?.head;
     const rows = this.getCorrectRows();
+    const convertRows: [TableRow, TableRow | null][] = [];
     let row = rows[0].next;
     while (row) {
       rows.unshift(row);
@@ -311,11 +314,15 @@ class TableMenus {
         const td = this.quill.scroll.create(domNode).replaceWith(TableCell.blotName, tdFormats);
         tdRow.insertBefore(td, null);
       });
-      tbody.insertBefore(tdRow, ref);
+      convertRows.unshift([tdRow, ref]);
       row.remove();
     }
+    for (const [row, ref] of convertRows) {
+      correctTbody.insertBefore(row, ref);
+    }
+    if (!tbody) tableBlot.insertBefore(correctTbody, null);
     // @ts-expect-error
-    const [td] = tbody.descendant(TableCell);
+    const [td] = correctTbody.descendant(TableCell);
     this.tableBetter.cellSelection.setSelected(td.domNode);
   }
 

--- a/src/ui/toolbar-table.ts
+++ b/src/ui/toolbar-table.ts
@@ -51,6 +51,14 @@ class TableSelect {
     return container;
   }
 
+  getClickInfo(e: MouseEvent): [boolean, Element] {
+    const target = e.target as Element;
+    const container = target.closest('div.ql-table-select-container');
+    const span = target.closest('span[row]');
+    if (container && !span) return [true, span];
+    return [false, span];
+  }
+
   getComputeChildren(children: HTMLCollection, e: MouseEvent): Element[] {
     const computeChildren = [];
     const { clientX, clientY } = e;
@@ -70,8 +78,8 @@ class TableSelect {
   }
 
   handleClick(e: MouseEvent, insertTable: InsertTableHandler) {
-    this.toggle(this.root);
-    const span = (e.target as Element).closest('span[row]');
+    const [isBetweenSpans, span] = this.getClickInfo(e);
+    this.toggle(this.root, isBetweenSpans);
     if (!span) {
       // Click between two spans
       const child = this.computeChildren[this.computeChildren.length - 1];
@@ -117,8 +125,8 @@ class TableSelect {
     element && element.classList.remove('ql-hidden');
   }
 
-  toggle(element: Element) {
-    this.clearSelected(this.computeChildren);
+  toggle(element: Element, isBetweenSpans: boolean) {
+    if (!isBetweenSpans) this.clearSelected(this.computeChildren);
     element && element.classList.toggle('ql-hidden');
   }
 }

--- a/src/utils/clipboard-matchers.ts
+++ b/src/utils/clipboard-matchers.ts
@@ -51,7 +51,7 @@ function matchTableCell(node: HTMLTableCellElement, delta: Delta) {
     node.getAttribute('data-row') ||
     rows.indexOf((node.parentNode as HTMLTableRowElement)) + 1;
   const cellId = node?.firstElementChild?.getAttribute('data-cell') || cells.indexOf(node) + 1;
-  if (!delta.length()) delta.insert('\n', { blotName: { 'data-row': row } });
+  if (!delta.length()) delta.insert('\n', { [blotName]: { 'data-row': row } });
   delta.ops.forEach(op => {
     if (op.attributes && op.attributes[blotName]) {
       // @ts-ignore


### PR DESCRIPTION
fix: Configuration for table-better is absent (#117).
fix: Clicking between cells creates no table (#115).
fix: Copy a blank table from Excel (#113).
fix: Copy and paste a table that contains a header row does not work (#112).
fix: Order error after header row switch.