### PR TITLE
Bugfix: Added null cell check to exitTableFocus

### DIFF
--- a/src/ui/cell-selection.ts
+++ b/src/ui/cell-selection.ts
@@ -97,6 +97,7 @@ class CellSelection {
 
   exitTableFocus(block: TableCellChildren, up: boolean) {
     const cell = getCorrectCellBlot(block);
+    if(!cell) return;
     const table = cell.table();
     const offset = up ? -1 : table.length();
     const index = table.offset(this.quill.scroll) + offset;


### PR DESCRIPTION
Change:
- [x] Added falsey check to the response from `getCorrectCellBlot(blot: TableCellChildren | TableCell): TableCell | null` in the `exitTableFocus` function. This missing null check caused `cell.table()` in follow line to throw null error

Fixes this issue: https://github.com/attoae/quill-table-better/issues/128
