### PR TITLE
allow headerTable option to initialize a table with table headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const toolbarOptions = [
 ```
 
 ### headerTable
-`headerTable` allows the table to be initilized where the first table row includes table header `<th>` elements.  
+`headerTable` allows the table to be initialized where the first table row includes table header `<th>` elements.  
 **Note** Headers may still be toggled on/off via the table row menu.
 
 ### toolbarButtons

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ const options = {
     'table-better': {
       language: 'en_US',
       menus: ['column', 'row', 'merge', 'table', 'cell', 'wrap', 'copy', 'delete'],
-      toolbarTable: true
+      toolbarTable: true,
+      headerTable: false,
     },
     keyboard: {
       bindings: QuillTableBetter.keyboardBindings
@@ -99,7 +100,8 @@ cdn
       'table-better': {
         language: 'en_US',
         menus: ['column', 'row', 'merge', 'table', 'cell', 'wrap', 'copy', 'delete'],
-        toolbarTable: true
+        toolbarTable: true,
+        headerTable: false,
       },
       keyboard: {
         bindings: QuillTableBetter.keyboardBindings
@@ -192,6 +194,10 @@ const toolbarOptions = [
   ['table-better']
 ];
 ```
+
+### headerTable
+`headerTable` allows the table to be initilized where the first table row includes table header `<th>` elements.  
+**Note** Headers may still be toggled on/off via the table row menu.
 
 ### toolbarButtons
 `toolbarButtons` is used when focusing on the table, you can specify which buttons to disable and which not.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ toolbarButtons: {
     whiteList: ['link', 'image'],
     singleWhiteList: ['link', 'image']
   },
-  toolbarTable: true
+  toolbarTable: true,
+  headerTable: false,
 }
 ```
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -35,7 +35,8 @@ const options = {
     toolbar: toolbarOptions,
     table: false,
     'table-better': {
-      toolbarTable: true
+      toolbarTable: true,
+      headerTable: false,
     },
     keyboard: {
       bindings: QuillTableBetter.keyboardBindings


### PR DESCRIPTION
# Table Headers Option

## Overview

Allows the table to be initialized where the first table row includes table header `<th>` elements.

## Problems solved

- Increases the accessibility of the table by added more support for screen readers.  See [Table Accessibility](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Table_accessibility).

## Backward Compatibility

The optional headerTable boolean will remain false by default and not affect existing table creation.
