### PR TITLE
Menu and toolbar keyboard support

### DIFF
--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -21,7 +21,7 @@ import {
 } from './formats/table';
 import TableHeader from './formats/header';
 import { ListContainer } from './formats/list';
-import { 
+import {
   matchTable,
   matchTableCell,
   matchTableCol,
@@ -60,7 +60,7 @@ class Table extends Module {
   tableMenus: TableMenus;
   tableSelect: TableSelect;
   options: Options;
-  
+
   static keyboardBindings: { [propName: string]: BindingObject };
 
   static register() {
@@ -81,7 +81,7 @@ class Table extends Module {
       'modules/clipboard': TableClipboard
     }, true);
   }
-  
+
   constructor(quill: Quill, options: Options) {
     super(quill, options);
     quill.clipboard.addMatcher('td, th', matchTableCell);
@@ -357,6 +357,17 @@ const keyboardBindings = {
       const cell = getCorrectCellBlot(blot);
       cell && tableModule.cellSelection.setSelected(cell.domNode, false);
     }
+  },
+  'table-cell shift tab': {
+    key: 'Tab',
+    collapsed: true,
+    shiftKey: true,
+    format: ['table-cell', 'table-th'],
+    handler(range: Range, context: Context) {
+      const tableModule = this.quill.getModule('table-better');
+      tableModule?.tableMenus.focusMenu();
+      return false;
+    }
   }
 }
 
@@ -429,7 +440,7 @@ function makeTableListHandler(key: string) {
     handler(range: Range, context: Context) {
       const [line] = this.quill.getLine(range.index);
       const cellId = getCellId(line.parent.formats()[line.parent.statics.blotName]);
-      line.replaceWith(TableCellBlock.blotName, cellId);      
+      line.replaceWith(TableCellBlock.blotName, cellId);
     }
   }
 }

--- a/src/ui/toolbar-table.ts
+++ b/src/ui/toolbar-table.ts
@@ -123,6 +123,8 @@ class TableSelect {
       case 'Enter':
         this.insertTableHandler(this.keyboardY + 1, this.keyboardX + 1);
         this.hide(this.root);
+        this.keyboardX = 0;
+        this.keyboardY = 0;
         break;
     }
 

--- a/src/ui/toolbar-table.ts
+++ b/src/ui/toolbar-table.ts
@@ -8,12 +8,16 @@ const icons = Quill.import('ui/icons');
 // @ts-expect-error
 icons['table-better'] = tableIcon;
 const SUM = 10;
- 
-class ToolbarTable extends Inline {};
+
+class ToolbarTable extends Inline { };
 
 class TableSelect {
   computeChildren: Element[];
   root: HTMLDivElement;
+  keyboardX = 0;
+  keyboardY = 0;
+  insertTableHandler: InsertTableHandler;
+
   constructor() {
     this.computeChildren = [];
     this.root = this.createContainer();
@@ -37,6 +41,8 @@ class TableSelect {
         const child = document.createElement('span');
         child.setAttribute('row', `${row}`);
         child.setAttribute('column', `${column}`);
+        child.setAttribute('tabindex', '0');
+        child.setAttribute('aria-label', `Row ${row} Column: ${column}`);
         fragment.appendChild(child);
       }
     }
@@ -45,9 +51,11 @@ class TableSelect {
     list.classList.add('ql-table-select-list');
     label.classList.add('ql-table-select-label');
     list.appendChild(fragment);
+    list.setAttribute('tabindex', '0');
     container.appendChild(list);
     container.appendChild(label);
     container.addEventListener('mousemove', e => this.handleMouseMove(e, container));
+    container.addEventListener('keydown', e => this.handleKeyboardMove(e, container));
     return container;
   }
 
@@ -78,15 +86,59 @@ class TableSelect {
   }
 
   handleClick(e: MouseEvent, insertTable: InsertTableHandler) {
+    this.insertTableHandler = insertTable;
     const [isBetweenSpans, span] = this.getClickInfo(e);
     this.toggle(this.root, isBetweenSpans);
     if (!span) {
       // Click between two spans
       const child = this.computeChildren[this.computeChildren.length - 1];
       if (child) this.insertTable(child, insertTable);
+      // Focus select container (only works if 'clicked' by keyboard)
+      (this.root.firstChild as HTMLDivElement).focus()
       return;
     }
     this.insertTable(span, insertTable);
+  }
+
+  handleKeyboardMove(event: KeyboardEvent, container: Element) {
+    event.preventDefault();
+
+    function clamp(coord: number, delta: -1 | 1) {
+      return Math.min(Math.max(0, coord + delta), SUM - 1)
+    }
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        this.keyboardX = clamp(this.keyboardX, -1);
+        break;
+      case 'ArrowRight':
+        this.keyboardX = clamp(this.keyboardX, 1);
+        break;
+      case 'ArrowUp':
+        this.keyboardY = clamp(this.keyboardY, -1);
+        break;
+      case 'ArrowDown':
+        this.keyboardY = clamp(this.keyboardY, 1);
+        break;
+      case 'Enter':
+        this.insertTableHandler(this.keyboardY + 1, this.keyboardX + 1);
+        this.hide(this.root);
+        break;
+    }
+
+    container.firstChild.childNodes.forEach((child: HTMLSpanElement) => {
+      child.classList.remove('ql-cell-selected');
+    });
+
+    let lastSquare: HTMLElement = container.firstChild.firstChild as HTMLElement;
+    for (let x = 0; x <= this.keyboardX; x++) {
+      for (let y = 0; y <= this.keyboardY; y++) {
+        const square = container.querySelector(`span[row="${y + 1}"][column="${x + 1}"]`)
+        square.classList && square.classList.add('ql-cell-selected');
+        lastSquare = square as HTMLElement;
+      }
+    }
+    lastSquare.focus();
   }
 
   handleMouseMove(e: MouseEvent, container: Element) {

--- a/src/ui/toolbar-table.ts
+++ b/src/ui/toolbar-table.ts
@@ -139,6 +139,7 @@ class TableSelect {
       }
     }
     lastSquare.focus();
+     this.setLabelContent(container.lastElementChild, lastSquare);
   }
 
   handleMouseMove(e: MouseEvent, container: Element) {


### PR DESCRIPTION

# Keyboard Support For Table Menu and Toolbar

## Overview

Allows the use of a keyboard to navigate and activate the various options in the Table Menu and the Table Toolbar.

## Problems solved

- Adds keyboard accessibility for table menus and sub-menus by allowing the following keys to perform navigation/actions: Arrows keys, Enter, Space, and Escape.
- Allows keyboard navigation to the table menu while the cursor is inside the table. (via `Shift+Tab`)
- Added keyboard navigation for table select button and container.

## Backward Compatibility

All added key-binds and keyboard actions fully support all existing mouse based click events and do not modify any existing behaviors. 

Existing default keyboard actions for `Shift + Tab`, while cursor is in a table-cell or table-th, will be overridden and will set focus to the table menu.
