### PR TITLE
fix: handle attribute key ordering, setContents, and raw array inputs

### DIFF
--- a/src/formats/table.ts
+++ b/src/formats/table.ts
@@ -130,11 +130,12 @@ class TableCell extends Container {
     return false;
   }
   
-  static create(value: Props) {
+  static create(value?: Props) {
     const node = super.create() as HTMLElement;
-    const keys = Object.keys(value);
-    for (const key of keys) {
-      value[key] && node.setAttribute(key, value[key]);
+    if (value != null && typeof value === 'object') {
+      for (const key of Object.keys(value)) {
+        value[key] && node.setAttribute(key, value[key]);
+      }
     }
     return node;
   }
@@ -327,15 +328,16 @@ class TableTemporary extends Block {
 
   next: this | null;
 
-  static create(value: Props) {
+  static create(value?: Props) {
     const node = super.create();
-    const keys = Object.keys(value);
-    const className = TableContainer.defaultClassName;
-    for (const key of keys) {
-      if (key === 'data-class' && !~value[key].indexOf(className)) {
-        node.setAttribute(key, `${className} ${value[key]}`);
-      } else {
-        node.setAttribute(key, value[key]);
+    if (value != null && typeof value === 'object') {
+      const className = TableContainer.defaultClassName;
+      for (const key of Object.keys(value)) {
+        if (key === 'data-class' && !~value[key].indexOf(className)) {
+          node.setAttribute(key, `${className} ${value[key]}`);
+        } else {
+          node.setAttribute(key, value[key]);
+        }
       }
     }
     return node;
@@ -383,11 +385,12 @@ class TableCol extends Block {
 
   next: this | null;
 
-  static create(value: Props) {
+  static create(value?: Props) {
     const node = super.create();
-    const keys = Object.keys(value);
-    for (const key of keys) {
-      node.setAttribute(key, value[key]);
+    if (value != null && typeof value === 'object') {
+      for (const key of Object.keys(value)) {
+        node.setAttribute(key, value[key]);
+      }
     }
     return node;
   }

--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -101,10 +101,15 @@ class Table extends Module {
     this.registerToolbarTable(options?.toolbarTable);
   }
 
-  // Ensure table-related attributes in delta ops are always processed in the
-  // correct order, regardless of how they arrive from the server.  Quill's
-  // applyDelta iterates Object.keys(attributes); line formats must come before
-  // container formats for the blot hierarchy to build correctly.
+  // Patch setContents and updateContents to:
+  // 1. Normalize table attribute ordering (line formats before container
+  //    formats) so the blot hierarchy builds correctly regardless of how
+  //    keys are ordered in the incoming delta.
+  // 2. Route setContents through updateContents (applyDelta) instead of
+  //    insertContents, because Quill's Scroll.createBlock() misidentifies
+  //    table container blots (TableCell, TableTh) as block-level line blots,
+  //    breaking the blot hierarchy.
+  //    See: https://github.com/slab/quill/pull/4398
   private patchContentMethods(quill: Quill) {
     const normalize = (delta: Delta | { ops: Delta['ops'] }) => {
       if (delta instanceof Delta) {
@@ -116,15 +121,21 @@ class Table extends Module {
       return delta;
     };
 
-    const origSetContents = quill.setContents.bind(quill);
-    quill.setContents = ((delta: any, source?: any) => {
-      return origSetContents(normalize(delta), source);
-    }) as typeof quill.setContents;
-
     const origUpdateContents = quill.updateContents.bind(quill);
     quill.updateContents = ((delta: any, source?: any) => {
       return origUpdateContents(normalize(delta), source);
     }) as typeof quill.updateContents;
+
+    // Route setContents through updateContents (applyDelta path).
+    // applyDelta builds the table hierarchy correctly from the inside out
+    // via TableCellBlock.format(), whereas insertContents/createBlock
+    // tries to build it from the outside in and misidentifies containers.
+    quill.setContents = ((delta: any, source?: any) => {
+      const normalized = normalize(delta) as Delta;
+      const length = quill.getLength();
+      const combined = new Delta().delete(length).concat(normalized);
+      return origUpdateContents(combined, source);
+    }) as typeof quill.setContents;
   }
 
   clearHistorySelected() {

--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -32,7 +32,7 @@ import CellSelection from './ui/cell-selection';
 import OperateLine from './ui/operate-line';
 import TableMenus from './ui/table-menus';
 import ToolbarTable, { TableSelect } from './ui/toolbar-table';
-import { getCellId, getCorrectCellBlot } from './utils';
+import { getCellId, getCorrectCellBlot, normalizeTableAttributes } from './utils';
 import TableToolbar from './modules/toolbar';
 import TableClipboard from './modules/clipboard';
 
@@ -84,6 +84,7 @@ class Table extends Module {
   
   constructor(quill: Quill, options: Options) {
     super(quill, options);
+    this.patchContentMethods(quill);
     quill.clipboard.addMatcher('td, th', matchTableCell);
     quill.clipboard.addMatcher('tr', matchTable);
     quill.clipboard.addMatcher('col', matchTableCol);
@@ -98,6 +99,32 @@ class Table extends Module {
     quill.root.addEventListener('scroll', this.handleScroll.bind(this));
     this.listenDeleteTable();
     this.registerToolbarTable(options?.toolbarTable);
+  }
+
+  // Ensure table-related attributes in delta ops are always processed in the
+  // correct order, regardless of how they arrive from the server.  Quill's
+  // applyDelta iterates Object.keys(attributes); line formats must come before
+  // container formats for the blot hierarchy to build correctly.
+  private patchContentMethods(quill: Quill) {
+    const normalize = (delta: Delta | { ops: Delta['ops'] }) => {
+      if (delta instanceof Delta) {
+        return new Delta(normalizeTableAttributes(delta.ops));
+      }
+      if (delta && Array.isArray((delta as any).ops)) {
+        return new Delta(normalizeTableAttributes((delta as any).ops));
+      }
+      return delta;
+    };
+
+    const origSetContents = quill.setContents.bind(quill);
+    quill.setContents = ((delta: any, source?: any) => {
+      return origSetContents(normalize(delta), source);
+    }) as typeof quill.setContents;
+
+    const origUpdateContents = quill.updateContents.bind(quill);
+    quill.updateContents = ((delta: any, source?: any) => {
+      return origUpdateContents(normalize(delta), source);
+    }) as typeof quill.updateContents;
   }
 
   clearHistorySelected() {

--- a/src/quill-table-better.ts
+++ b/src/quill-table-better.ts
@@ -118,7 +118,10 @@ class Table extends Module {
       if (delta && Array.isArray((delta as any).ops)) {
         return new Delta(normalizeTableAttributes((delta as any).ops));
       }
-      return delta;
+      if (Array.isArray(delta)) {
+        return new Delta(normalizeTableAttributes(delta as any));
+      }
+      return new Delta(delta as any);
     };
 
     const origUpdateContents = quill.updateContents.bind(quill);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -375,6 +375,73 @@ function throttleStrong(cb: Function, delay: number) {
   }
 }
 
+/**
+ * Normalize table-related attribute ordering in delta ops.
+ *
+ * Quill's applyDelta iterates Object.keys(attributes) to apply formats.
+ * For table blots, line formats (table-cell-block, table-th-block) MUST be
+ * processed before their container formats (table-cell, table-th), because
+ * the line format replaces the Block with a TableCellBlock whose format()
+ * method knows how to wrap itself in the correct container with the right
+ * value.  When the container format is iterated first, the line is still a
+ * plain Block which doesn't handle it, causing Parchment to call
+ * TableCell.create() without a value → TypeError.
+ *
+ * Server-side delta pipelines (e.g. Python OT libraries using JSON
+ * serialization) can reorder dict/object keys, breaking the required order.
+ * This function ensures line formats always precede container formats
+ * regardless of the original key ordering.
+ */
+function normalizeTableAttributes<T extends { attributes?: Record<string, unknown> }>(ops: T[]): T[] {
+  const LINE_FORMATS = ['table-cell-block', 'table-th-block'];
+  const CONTAINER_FORMATS = ['table-cell', 'table-th'];
+
+  return ops.map(op => {
+    const attrs = op.attributes;
+    if (!attrs) return op;
+
+    // Check if this op has both a line format and its container format
+    const hasLineFormat = LINE_FORMATS.some(f => f in attrs);
+    const hasContainerFormat = CONTAINER_FORMATS.some(f => f in attrs);
+    if (!hasLineFormat || !hasContainerFormat) return op;
+
+    // Check if any container format key appears before its line format key
+    const keys = Object.keys(attrs);
+    let needsReorder = false;
+    for (let i = 0; i < LINE_FORMATS.length; i++) {
+      const lineKey = LINE_FORMATS[i];
+      const containerKey = CONTAINER_FORMATS[i];
+      if (lineKey in attrs && containerKey in attrs) {
+        if (keys.indexOf(containerKey) < keys.indexOf(lineKey)) {
+          needsReorder = true;
+          break;
+        }
+      }
+    }
+    if (!needsReorder) return op;
+
+    // Rebuild attributes with line formats before container formats
+    const reordered: Record<string, unknown> = {};
+    const lineSet = new Set(LINE_FORMATS);
+    const containerSet = new Set(CONTAINER_FORMATS);
+    // First: all non-table-hierarchy keys (preserve their relative order)
+    for (const k of keys) {
+      if (!lineSet.has(k) && !containerSet.has(k)) {
+        reordered[k] = attrs[k];
+      }
+    }
+    // Then: line formats
+    for (const k of LINE_FORMATS) {
+      if (k in attrs) reordered[k] = attrs[k];
+    }
+    // Then: container formats
+    for (const k of CONTAINER_FORMATS) {
+      if (k in attrs) reordered[k] = attrs[k];
+    }
+    return { ...op, attributes: reordered };
+  });
+}
+
 function updateTableWidth(
   table: HTMLElement,
   tableBounds: CorrectBound,
@@ -436,6 +503,7 @@ export {
   isDimensions,
   isValidColor,
   isValidDimensions,
+  normalizeTableAttributes,
   removeElementProperty,
   rgbToHex,
   rgbaToHex,

--- a/test/normalize-table-attributes.test.js
+++ b/test/normalize-table-attributes.test.js
@@ -1,0 +1,243 @@
+/**
+ * Tests for normalizeTableAttributes utility.
+ *
+ * When delta ops are round-tripped through a server (e.g. Python's orjson,
+ * or any JSON serializer that doesn't preserve key order), the attribute
+ * keys on table ops can arrive in an arbitrary order.  Quill's applyDelta
+ * iterates Object.keys(attributes), and table blots require line formats
+ * (table-cell-block, table-th-block) to be processed BEFORE their container
+ * formats (table-cell, table-th).  If the container format is processed
+ * first, Parchment calls TableCell.create() without a value, causing:
+ *
+ *   TypeError: undefined is not an object (evaluating 'Object.keys(e)')
+ *
+ * normalizeTableAttributes reorders the attributes so line formats always
+ * come before container formats, making the module robust against any
+ * server-side key reordering.
+ *
+ * Run: node test/normalize-table-attributes.test.js
+ */
+
+// Inline the function to keep the test self-contained (no build step needed).
+// This is an exact copy of the logic in src/utils/index.ts.
+
+function normalizeTableAttributes(ops) {
+  var LINE_FORMATS = ['table-cell-block', 'table-th-block'];
+  var CONTAINER_FORMATS = ['table-cell', 'table-th'];
+
+  return ops.map(function (op) {
+    var attrs = op.attributes;
+    if (!attrs) return op;
+
+    var hasLineFormat = LINE_FORMATS.some(function (f) { return f in attrs; });
+    var hasContainerFormat = CONTAINER_FORMATS.some(function (f) { return f in attrs; });
+    if (!hasLineFormat || !hasContainerFormat) return op;
+
+    var keys = Object.keys(attrs);
+    var needsReorder = false;
+    for (var i = 0; i < LINE_FORMATS.length; i++) {
+      var lineKey = LINE_FORMATS[i];
+      var containerKey = CONTAINER_FORMATS[i];
+      if (lineKey in attrs && containerKey in attrs) {
+        if (keys.indexOf(containerKey) < keys.indexOf(lineKey)) {
+          needsReorder = true;
+          break;
+        }
+      }
+    }
+    if (!needsReorder) return op;
+
+    var reordered = {};
+    var lineSet = new Set(LINE_FORMATS);
+    var containerSet = new Set(CONTAINER_FORMATS);
+    keys.forEach(function (k) {
+      if (!lineSet.has(k) && !containerSet.has(k)) {
+        reordered[k] = attrs[k];
+      }
+    });
+    LINE_FORMATS.forEach(function (k) {
+      if (k in attrs) reordered[k] = attrs[k];
+    });
+    CONTAINER_FORMATS.forEach(function (k) {
+      if (k in attrs) reordered[k] = attrs[k];
+    });
+    return Object.assign({}, op, { attributes: reordered });
+  });
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function attrKeys(op) {
+  return Object.keys(op.attributes || {});
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error('FAIL: ' + message);
+  }
+}
+
+function assertDeepEqual(actual, expected, message) {
+  var a = JSON.stringify(actual);
+  var e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error('FAIL: ' + message + '\n  expected: ' + e + '\n  actual:   ' + a);
+  }
+}
+
+var passed = 0;
+var failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  \u2713 ' + name);
+  } catch (e) {
+    failed++;
+    console.error('  \u2717 ' + name);
+    console.error('    ' + e.message);
+  }
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+console.log('normalizeTableAttributes');
+
+test('passes through ops without attributes unchanged', function () {
+  var ops = [{ insert: 'hello' }, { insert: '\n' }];
+  var result = normalizeTableAttributes(ops);
+  assertDeepEqual(result, ops, 'ops should be unchanged');
+});
+
+test('passes through ops with only line format (no container)', function () {
+  var ops = [
+    { insert: '\n', attributes: { 'table-cell-block': 'cell-abc' } }
+  ];
+  var result = normalizeTableAttributes(ops);
+  assertDeepEqual(result, ops, 'ops should be unchanged');
+});
+
+test('passes through ops with only container format (no line)', function () {
+  var ops = [
+    { insert: '\n', attributes: { 'table-cell': { 'data-row': 'row-123' } } }
+  ];
+  var result = normalizeTableAttributes(ops);
+  assertDeepEqual(result, ops, 'ops should be unchanged');
+});
+
+test('preserves correct order: table-cell-block before table-cell', function () {
+  var ops = [{
+    insert: '\n',
+    attributes: {
+      'table-cell-block': 'cell-abc',
+      'table-cell': { 'data-row': 'row-123' }
+    }
+  }];
+  var result = normalizeTableAttributes(ops);
+  // Already correct order — should return same object reference
+  assert(result[0] === ops[0], 'should return same object when order is correct');
+});
+
+test('reorders: table-cell before table-cell-block → fixed', function () {
+  // This is the bug case: container format before line format
+  var ops = [{
+    insert: '\n',
+    attributes: {
+      'table-cell': { 'data-row': 'row-zft5' },
+      'table-cell-block': 'cell-audy'
+    }
+  }];
+  var result = normalizeTableAttributes(ops);
+  var keys = attrKeys(result[0]);
+  var lineIdx = keys.indexOf('table-cell-block');
+  var containerIdx = keys.indexOf('table-cell');
+  assert(lineIdx < containerIdx,
+    'table-cell-block (' + lineIdx + ') should come before table-cell (' + containerIdx + ')');
+  // Values must be preserved
+  assertDeepEqual(result[0].attributes['table-cell-block'], 'cell-audy', 'line format value');
+  assertDeepEqual(result[0].attributes['table-cell'], { 'data-row': 'row-zft5' }, 'container format value');
+});
+
+test('reorders: table-th before table-th-block → fixed', function () {
+  var ops = [{
+    insert: '\n',
+    attributes: {
+      'table-th': { 'data-row': 'row-abc' },
+      'table-th-block': 'cell-xyz'
+    }
+  }];
+  var result = normalizeTableAttributes(ops);
+  var keys = attrKeys(result[0]);
+  assert(keys.indexOf('table-th-block') < keys.indexOf('table-th'),
+    'table-th-block should come before table-th');
+});
+
+test('preserves other attributes and their relative order', function () {
+  var ops = [{
+    insert: '\n',
+    attributes: {
+      'bold': true,
+      'table-cell': { 'data-row': 'row-1' },
+      'color': '#ff0000',
+      'table-cell-block': 'cell-1'
+    }
+  }];
+  var result = normalizeTableAttributes(ops);
+  var keys = attrKeys(result[0]);
+  // bold and color should come first (in their original relative order)
+  assert(keys.indexOf('bold') < keys.indexOf('color'), 'bold before color');
+  // Then line format, then container format
+  assert(keys.indexOf('color') < keys.indexOf('table-cell-block'), 'color before table-cell-block');
+  assert(keys.indexOf('table-cell-block') < keys.indexOf('table-cell'), 'table-cell-block before table-cell');
+});
+
+test('handles multiple ops, only reorders those that need it', function () {
+  var ops = [
+    { insert: 'text' },
+    {
+      insert: '\n',
+      attributes: {
+        'table-cell-block': 'cell-ok',
+        'table-cell': { 'data-row': 'row-ok' }
+      }
+    },
+    {
+      insert: '\n',
+      attributes: {
+        'table-cell': { 'data-row': 'row-bad' },
+        'table-cell-block': 'cell-bad'
+      }
+    },
+    { insert: '\n', attributes: { 'header': 1 } }
+  ];
+  var result = normalizeTableAttributes(ops);
+  // First op: no attributes, same reference
+  assert(result[0] === ops[0], 'plain text op unchanged');
+  // Second op: already correct order, same reference
+  assert(result[1] === ops[1], 'correctly ordered op unchanged');
+  // Third op: was reordered
+  assert(result[2] !== ops[2], 'misordered op should be new object');
+  var keys = attrKeys(result[2]);
+  assert(keys.indexOf('table-cell-block') < keys.indexOf('table-cell'),
+    'reordered op has correct key order');
+  // Fourth op: no table formats, same reference
+  assert(result[3] === ops[3], 'non-table op unchanged');
+});
+
+test('preserves insert value during reorder', function () {
+  var ops = [{
+    insert: '\n',
+    attributes: {
+      'table-cell': { 'data-row': 'row-1' },
+      'table-cell-block': 'cell-1'
+    }
+  }];
+  var result = normalizeTableAttributes(ops);
+  assert(result[0].insert === '\n', 'insert value preserved');
+});
+
+// ── summary ──────────────────────────────────────────────────────────
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Three related fixes for loading table content from external sources (server-side delta pipelines, APIs, etc.).

### Bug 1: Attribute key ordering crash

When delta ops are round-tripped through a server-side pipeline (e.g. Python OT libraries using JSON serialization like `orjson`), object key ordering can change. Quill's `applyDelta` iterates `Object.keys(attributes)` to apply formats, and quill-table-better's blot hierarchy requires line formats (`table-cell-block`, `table-th-block`) to be processed **before** their container formats (`table-cell`, `table-th`).

When the container format key appears first in iteration order, Quill applies it to a plain `Block` (not yet replaced by `TableCellBlock`), and Parchment's `wrap()` calls `TableCell.create()` without a value, causing:

```
TypeError: undefined is not an object (evaluating 'Object.keys(e)')
```

**Fix**: `normalizeTableAttributes()` utility ensures line formats always precede container formats in attribute key iteration order, applied automatically via patched `setContents`/`updateContents` methods.

### Bug 2: `setContents()` does not render tables

Quill's `Scroll.createBlock()` (used by `setContents` via `editor.insertContents`) misidentifies table container blots (`TableCell`, `TableTh`) as block-level line blots, because `ContainerBlot.scope` includes `BLOCK_BLOT`. This causes the table hierarchy to be built incorrectly — containers get inserted directly into Scroll without their required parents.

See: https://github.com/slab/quill/pull/4398

**Fix**: Routes `setContents` through `updateContents` (which uses `editor.applyDelta`), building the hierarchy correctly from the inside out via `TableCellBlock.format()`.

### Bug 3: Defensive `create()` methods

`TableCell.create()`, `TableTemporary.create()`, and `TableCol.create()` called `Object.keys(value)` without checking if `value` was defined. Parchment's `wrap()` can call `create()` without a value.

**Fix**: All three `create()` methods now handle `undefined`/`null` gracefully.

### Bug 4: Raw array input to patched setContents

Quill's `setContents` accepts raw ops arrays, Delta instances, and `{ops: [...]}` objects. The patched method only handled the latter two, so passing a raw array caused `concat()` to crash.

**Fix**: The normalize function now handles all input forms.

### Reproducing the bugs

```javascript
// Bug 1 — crashes without fix (container format key before line format key):
quill.setContents([{insert: '\n', attributes: {'table-cell': {'data-row': 'row-1'}, 'table-cell-block': 'cell-1'}}]);

// Bug 2 — table doesn't render without fix (setContents vs updateContents):
quill.setContents([{insert: '\n', attributes: {'table-cell-block': 'cell-1', 'table-cell': {'data-row': 'row-1'}}}]);

// Bug 4 — crashes without fix (raw array instead of Delta):
quill.setContents([{insert: 'hello'}, {insert: '\n'}]);
```

### Test

Includes `test/normalize-table-attributes.test.js` — run with `node test/normalize-table-attributes.test.js` (9 tests).

### Files changed

- `src/utils/index.ts` — `normalizeTableAttributes()` utility
- `src/quill-table-better.ts` — `patchContentMethods()` in module constructor
- `src/formats/table.ts` — defensive `create()` on TableCell, TableTemporary, TableCol
- `test/normalize-table-attributes.test.js` — tests for attribute normalization